### PR TITLE
[chore] Use io.jenkins.plugins as groupId

### DIFF
--- a/mina-sshd-common/pom.xml
+++ b/mina-sshd-common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jenkins-ci.plugins.mina-sshd-api</groupId>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
         <artifactId>mina-sshd-api-parent</artifactId>
         <version>${revision}-${changelist}</version>
     </parent>

--- a/mina-sshd-core/pom.xml
+++ b/mina-sshd-core/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jenkins-ci.plugins.mina-sshd-api</groupId>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
         <artifactId>mina-sshd-api-parent</artifactId>
         <version>${revision}-${changelist}</version>
     </parent>
@@ -22,7 +22,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.mina-sshd-api</groupId>
+            <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
             <artifactId>mina-sshd-common-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/mina-sshd-scp/pom.xml
+++ b/mina-sshd-scp/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jenkins-ci.plugins.mina-sshd-api</groupId>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
         <artifactId>mina-sshd-api-parent</artifactId>
         <version>${revision}-${changelist}</version>
     </parent>
@@ -22,7 +22,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.mina-sshd-api</groupId>
+            <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
             <artifactId>mina-sshd-core-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/mina-sshd-sftp/pom.xml
+++ b/mina-sshd-sftp/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jenkins-ci.plugins.mina-sshd-api</groupId>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
         <artifactId>mina-sshd-api-parent</artifactId>
         <version>${revision}-${changelist}</version>
     </parent>
@@ -22,7 +22,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.mina-sshd-api</groupId>
+            <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
             <artifactId>mina-sshd-core-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <relativePath/>
     </parent>
 
-    <groupId>org.jenkins-ci.plugins.mina-sshd-api</groupId>
+    <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
     <artifactId>mina-sshd-api-parent</artifactId>
     <version>${revision}-${changelist}</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
As discussed in https://github.com/jenkins-infra/repository-permissions-updater/pull/2583, we should use group ID `io.jenkins.plugins`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue