### PR TITLE
Remove redundant `<version>`

### DIFF
--- a/mina-sshd-common/pom.xml
+++ b/mina-sshd-common/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>mina-sshd-common-api</artifactId>
-    <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Mina SSHD API :: Common</name>

--- a/mina-sshd-core/pom.xml
+++ b/mina-sshd-core/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>mina-sshd-core-api</artifactId>
-    <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Mina SSHD API :: Core</name>

--- a/mina-sshd-scp/pom.xml
+++ b/mina-sshd-scp/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>mina-sshd-scp-api</artifactId>
-    <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Mina SSHD API :: SCP</name>

--- a/mina-sshd-sftp/pom.xml
+++ b/mina-sshd-sftp/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>mina-sshd-sftp-api</artifactId>
-    <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Mina SSHD API :: SFTP</name>


### PR DESCRIPTION
Unfortunately does not fix

```bash
mvn validate -Dset.changelist
```

which still fails with

```
…
[ERROR] Failed to execute goal on project mina-sshd-core-api: Could not resolve dependencies for project org.jenkins-ci.plugins.mina-sshd-api:mina-sshd-core-api:hpi:2.8.0-3.vd9a_6e308feee: Could not find artifact org.jenkins-ci.plugins.mina-sshd-api:mina-sshd-common-api:jar:2.8.0-3.vd9a_6e308feee in repo.jenkins-ci.org (https://repo.jenkins-ci.org/public/) -> [Help 1]
```

Some sort of issue with `flatten-maven-plugin` I suppose. Note that

```bash
mvn -Pquick-build install -Dset.changelist
```

works because of the local repo. Cannot recall if I ever solved this situation properly.
