### PR TITLE
[chore] Use the pattern mina-sshd-api-<moduleName>

### DIFF
--- a/mina-sshd-common/pom.xml
+++ b/mina-sshd-common/pom.xml
@@ -10,7 +10,7 @@
         <version>${revision}-${changelist}</version>
     </parent>
 
-    <artifactId>mina-sshd-common-api</artifactId>
+    <artifactId>mina-sshd-api-common</artifactId>
     <packaging>hpi</packaging>
 
     <name>Mina SSHD API :: Common</name>

--- a/mina-sshd-core/pom.xml
+++ b/mina-sshd-core/pom.xml
@@ -10,7 +10,7 @@
         <version>${revision}-${changelist}</version>
     </parent>
 
-    <artifactId>mina-sshd-core-api</artifactId>
+    <artifactId>mina-sshd-api-core</artifactId>
     <packaging>hpi</packaging>
 
     <name>Mina SSHD API :: Core</name>
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
-            <artifactId>mina-sshd-common-api</artifactId>
+            <artifactId>mina-sshd-api-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/mina-sshd-scp/pom.xml
+++ b/mina-sshd-scp/pom.xml
@@ -10,7 +10,7 @@
         <version>${revision}-${changelist}</version>
     </parent>
 
-    <artifactId>mina-sshd-scp-api</artifactId>
+    <artifactId>mina-sshd-api-scp</artifactId>
     <packaging>hpi</packaging>
 
     <name>Mina SSHD API :: SCP</name>
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
-            <artifactId>mina-sshd-core-api</artifactId>
+            <artifactId>mina-sshd-api-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/mina-sshd-sftp/pom.xml
+++ b/mina-sshd-sftp/pom.xml
@@ -10,7 +10,7 @@
         <version>${revision}-${changelist}</version>
     </parent>
 
-    <artifactId>mina-sshd-sftp-api</artifactId>
+    <artifactId>mina-sshd-api-sftp</artifactId>
     <packaging>hpi</packaging>
 
     <name>Mina SSHD API :: SFTP</name>
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
-            <artifactId>mina-sshd-core-api</artifactId>
+            <artifactId>mina-sshd-api-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix inconsistency in the module pattern - parent module was following `mina-sshd-api-*` but modules were following `mina-sshd-api-*`. It is best that the same pattern be used.

See https://github.com/jenkins-infra/repository-permissions-updater/pull/2593.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
