### PR TITLE
[JENKINS-64105] Add optional SSHAuthenticator implementation

### DIFF
--- a/mina-sshd-api-core/pom.xml
+++ b/mina-sshd-api-core/pom.xml
@@ -18,18 +18,6 @@
         This plugin provides the Apache Mina SSHD Core library to plugins.
     </description>
     <url>https://github.com/jenkinsci/mina-sshd-api-plugin</url>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
-                <version>1461.vb_3c6de28f2b_a_</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     
     <dependencies>
         <dependency>

--- a/mina-sshd-api-core/pom.xml
+++ b/mina-sshd-api-core/pom.xml
@@ -18,6 +18,18 @@
         This plugin provides the Apache Mina SSHD Core library to plugins.
     </description>
     <url>https://github.com/jenkinsci/mina-sshd-api-plugin</url>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1461.vb_3c6de28f2b_a_</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     
     <dependencies>
         <dependency>
@@ -44,6 +56,11 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ssh-credentials</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 </project>

--- a/mina-sshd-api-core/src/main/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticator.java
+++ b/mina-sshd-api-core/src/main/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticator.java
@@ -1,0 +1,139 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.plugins.mina_sshd_api.core.authenticators;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorFactory;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.Functions;
+import org.apache.sshd.client.auth.password.UserAuthPasswordFactory;
+import org.apache.sshd.client.session.ClientSession;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Does password auth with a {@link ClientSession}.
+ */
+public class MinaSSHPasswordKeyAuthenticator 
+    extends SSHAuthenticator<ClientSession, StandardUsernamePasswordCredentials> {
+
+    static /*almost final*/ int authTimeout = Integer.parseInt(
+        System.getProperty(MinaSSHPasswordKeyAuthenticator.class.getName() + ".authTimeout", "15"));
+
+    /**
+     * Constructor.
+     *
+     * @param connection the connection we will be authenticating.
+     * @since 1.4
+     */
+    MinaSSHPasswordKeyAuthenticator(@NonNull ClientSession connection,
+                                    @NonNull StandardUsernamePasswordCredentials user,
+                                    @CheckForNull String username) {
+        super(connection, user, username);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canAuthenticate() {
+        return getConnection().getUserAuthFactories().stream()
+            .anyMatch(userAuthFactory -> userAuthFactory instanceof UserAuthPasswordFactory)
+            && !getConnection().isAuthenticated()
+            && getConnection().isOpen();
+    }
+
+    @NonNull
+    @Override
+    public Mode getAuthenticationMode() {
+        return Mode.AFTER_CONNECT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean doAuthenticate() {
+        final String username = getUsername();
+        getConnection().addPasswordIdentity(getUser().getPassword().getPlainText());
+        try {
+            getConnection().setUsername(username);
+            return getConnection().auth().verify(authTimeout, TimeUnit.SECONDS).isSuccess();
+        } catch (IOException e) {
+            Functions.printStackTrace(e, getListener().error("Could not authenticate due to I/O issue"));
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Extension(optional = true)
+    public static class Factory extends SSHAuthenticatorFactory {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C connection,
+                                                                                                @NonNull U user) {
+            return newInstance(connection, user, null);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Nullable
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C connection,
+                                                                                                @NonNull U user,
+                                                                                                @CheckForNull String
+                                                                                                    username) {
+            if (supports(connection.getClass(), user.getClass())) {
+                return (SSHAuthenticator<C, U>) new MinaSSHPasswordKeyAuthenticator((ClientSession) connection,
+                    (StandardUsernamePasswordCredentials) user, username);
+            }
+            return null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected <C, U extends StandardUsernameCredentials> boolean supports(@NonNull Class<C> connectionClass,
+                                                                              @NonNull Class<U> userClass) {
+            return ClientSession.class.isAssignableFrom(connectionClass)
+                && StandardUsernamePasswordCredentials.class.isAssignableFrom(userClass);
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/mina-sshd-api-core/src/main/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticator.java
+++ b/mina-sshd-api-core/src/main/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticator.java
@@ -117,7 +117,7 @@ public class MinaSSHPasswordKeyAuthenticator
                                                                                                 @NonNull U user,
                                                                                                 @CheckForNull String
                                                                                                     username) {
-            if (supports(connection.getClass(), user.getClass())) {
+            if (connection instanceof ClientSession && user instanceof StandardUsernamePasswordCredentials) {
                 return (SSHAuthenticator<C, U>) new MinaSSHPasswordKeyAuthenticator((ClientSession) connection,
                     (StandardUsernamePasswordCredentials) user, username);
             }

--- a/mina-sshd-api-core/src/main/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPublicKeyAuthenticator.java
+++ b/mina-sshd-api-core/src/main/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPublicKeyAuthenticator.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.plugins.mina_sshd_api.core.authenticators;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorFactory;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.Functions;
+import hudson.util.Secret;
+import org.apache.sshd.client.auth.pubkey.UserAuthPublicKeyFactory;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.config.keys.FilePasswordProvider;
+import org.apache.sshd.common.util.io.resource.PathResource;
+import org.apache.sshd.common.util.security.SecurityUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Does public key auth with a {@link ClientSession}.
+ */
+public class MinaSSHPublicKeyAuthenticator extends SSHAuthenticator<ClientSession, SSHUserPrivateKey> {
+
+    static /*almost final*/ int authTimeout = Integer.parseInt(
+        System.getProperty(MinaSSHPublicKeyAuthenticator.class.getName() + ".authTimeout", "15"));
+
+    /**
+     * Constructor.
+     *
+     * @param connection the connection we will be authenticating.
+     */
+    MinaSSHPublicKeyAuthenticator(@NonNull ClientSession connection,
+                                  @NonNull SSHUserPrivateKey user,
+                                  @CheckForNull String username) {
+        super(connection, user, username);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canAuthenticate() {
+        return getConnection().getUserAuthFactories().stream()
+            .anyMatch(userAuthFactory -> userAuthFactory instanceof UserAuthPublicKeyFactory)
+            && !getConnection().isAuthenticated()
+            && getConnection().isOpen();
+    }
+
+    @NonNull
+    @Override
+    public Mode getAuthenticationMode() {
+        return Mode.AFTER_CONNECT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean doAuthenticate() {
+        final SSHUserPrivateKey user = getUser();
+        for (String key : user.getPrivateKeys()) {
+            try {
+                Secret passphrase = user.getPassphrase();
+                Path path = Paths.get("key");
+
+                SecurityUtils.loadKeyPairIdentities(null,
+                        new PathResource(path),
+                        new ByteArrayInputStream(key.getBytes(StandardCharsets.UTF_8)),
+                        passphrase == null ? null : FilePasswordProvider.of(passphrase.getPlainText()))
+                    .forEach(keyPair -> getConnection().addPublicKeyIdentity(keyPair));
+                getConnection().setUsername(getUsername());
+                return getConnection().auth().verify(authTimeout, TimeUnit.SECONDS).isSuccess();
+            } catch (IOException e) {
+                Functions.printStackTrace(e,
+                    getListener().error("Could not authenticate due to I/O issue"));
+            } catch (GeneralSecurityException e) {
+                Functions.printStackTrace(e,
+                    getListener().error("Could not authenticate because unrecoverable key pair"));
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Extension(optional = true)
+    public static class Factory extends SSHAuthenticatorFactory {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Nullable
+        @Override
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C connection,
+                                                                                                @NonNull U user) {
+            return newInstance(connection, user, null);
+        }
+
+
+        /**
+         * {@inheritDoc}
+         */
+        @Nullable
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C connection,
+                                                                                                @NonNull U user,
+                                                                                                @CheckForNull String
+                                                                                                    username) {
+            if (supports(connection.getClass(), user.getClass())) {
+                return (SSHAuthenticator<C, U>) new MinaSSHPublicKeyAuthenticator(
+                    (ClientSession) connection,
+                    (SSHUserPrivateKey) user,
+                    username
+                );
+            }
+            return null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected <C, U extends StandardUsernameCredentials> boolean supports(@NonNull Class<C> connectionClass,
+                                                                              @NonNull Class<U> userClass) {
+            return ClientSession.class.isAssignableFrom(connectionClass)
+                && SSHUserPrivateKey.class.isAssignableFrom(userClass);
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/mina-sshd-api-core/src/main/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPublicKeyAuthenticator.java
+++ b/mina-sshd-api-core/src/main/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPublicKeyAuthenticator.java
@@ -139,7 +139,7 @@ public class MinaSSHPublicKeyAuthenticator extends SSHAuthenticator<ClientSessio
                                                                                                 @NonNull U user,
                                                                                                 @CheckForNull String
                                                                                                     username) {
-            if (supports(connection.getClass(), user.getClass())) {
+            if (connection instanceof ClientSession && user instanceof SSHUserPrivateKey) {
                 return (SSHAuthenticator<C, U>) new MinaSSHPublicKeyAuthenticator(
                     (ClientSession) connection,
                     (SSHUserPrivateKey) user,

--- a/mina-sshd-api-core/src/main/test/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticatorTest.java
+++ b/mina-sshd-api-core/src/main/test/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticatorTest.java
@@ -72,25 +72,6 @@ public class MinaSSHPasswordKeyAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticate() throws Exception {
-        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
-            sshClient.start();
-            try (ClientSession connection = sshClient
-                .connect(user.getUsername(), sshd.getHost(), sshd.getPort())
-                .verify(15, TimeUnit.SECONDS)
-                .getClientSession()) {
-
-                MinaSSHPasswordKeyAuthenticator instance = 
-                    new MinaSSHPasswordKeyAuthenticator(connection, user, null);
-                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
-                assertThat(instance.canAuthenticate(), is(true));
-                assertThat(instance.authenticate(TaskListener.NULL), is(true));
-                assertThat(instance.isAuthenticated(), is(true));
-            }
-        }
-    }
-
-    @Test
     public void testFactory() throws Exception {
         try (SshClient sshClient = SshClient.setUpDefaultClient()) {
             sshClient.start();

--- a/mina-sshd-api-core/src/main/test/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticatorTest.java
+++ b/mina-sshd-api-core/src/main/test/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticatorTest.java
@@ -1,0 +1,111 @@
+package io.jenkins.plugins.mina_sshd_api.core.authenticators;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.TaskListener;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MinaSSHPasswordKeyAuthenticatorTest {
+
+    private static final Logger LOGGER = Logger.getLogger(MinaSSHPasswordKeyAuthenticatorTest.class.getName());
+
+    private SshServer sshd;
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    private final StandardUsernamePasswordCredentials user =
+        new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, null, "foobar", "foobar", "foomanchu");
+
+    @After
+    public void tearDown() {
+        if (sshd != null) {
+            try {
+                sshd.stop(true);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Problems shutting down ssh server", e);
+            }
+        }
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        sshd = SshServer.setUpDefaultServer();
+        sshd.setHost("localhost");
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        sshd.setPasswordAuthenticator((s, s1, serverSession) -> user.getUsername().equals(s) && user.getPassword().getPlainText().equals(s1));
+        sshd.setUserAuthFactories(Collections.singletonList(new UserAuthPasswordFactory()));
+        try {
+            sshd.start();
+            LOGGER.log(Level.INFO, "Started ssh Server");
+        } catch (Throwable e) {
+            LOGGER.log(Level.WARNING, "Problems starting ssh server", e);
+            try {
+                sshd.stop();
+            } catch (Throwable t) {
+                LOGGER.log(Level.WARNING, "Problems shutting down ssh server", t);
+            }
+            throw e;
+        }
+    }
+
+    @Test
+    public void testAuthenticate() throws Exception {
+        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
+            sshClient.start();
+            try (ClientSession connection = sshClient
+                .connect(user.getUsername(), sshd.getHost(), sshd.getPort())
+                .verify(15, TimeUnit.SECONDS)
+                .getClientSession()) {
+
+                MinaSSHPasswordKeyAuthenticator instance = 
+                    new MinaSSHPasswordKeyAuthenticator(connection, user, null);
+                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
+                assertThat(instance.canAuthenticate(), is(true));
+                assertThat(instance.authenticate(TaskListener.NULL), is(true));
+                assertThat(instance.isAuthenticated(), is(true));
+            }
+        }
+    }
+
+    @Test
+    public void testFactory() throws Exception {
+        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
+            sshClient.start();
+            try (ClientSession connection = sshClient
+                .connect(user.getUsername(), sshd.getHost(), sshd.getPort())
+                .verify(30, TimeUnit.SECONDS)
+                .getClientSession()) {
+
+                SSHAuthenticator<Object, StandardUsernameCredentials> instance = 
+                    SSHAuthenticator.newInstance(connection, user);
+                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
+                assertThat(instance.canAuthenticate(), is(true));
+                assertThat(instance.authenticate(TaskListener.NULL), is(true));
+                assertThat(instance.isAuthenticated(), is(true));
+            }
+        }
+    }
+}

--- a/mina-sshd-api-core/src/main/test/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPublicKeyAuthenticatorTest.java
+++ b/mina-sshd-api-core/src/main/test/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPublicKeyAuthenticatorTest.java
@@ -232,46 +232,6 @@ public class MinaSSHPublicKeyAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticate() throws Exception {
-        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
-            sshClient.start();
-            try (ClientSession connection = sshClient
-                .connect(user.getUsername(), sshd.getHost(), sshd.getPort())
-                .verify(15, TimeUnit.SECONDS)
-                .getSession()) {
-
-                MinaSSHPublicKeyAuthenticator instance = 
-                    new MinaSSHPublicKeyAuthenticator(connection, user, null);
-                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
-                assertThat(instance.canAuthenticate(), is(true));
-                assertThat(instance.authenticate(TaskListener.NULL), is(true));
-                assertThat(instance.isAuthenticated(), is(true));
-                assertThat(connection.getUsername(), is(user.getUsername()));
-            }
-        }
-    }
-
-    @Test
-    public void testAuthenticateWithPassphrase() throws Exception {
-        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
-            sshClient.start();
-            try (ClientSession connection = sshClient
-                .connect(userWithPassphrase.getUsername(), sshd.getHost(), sshd.getPort())
-                .verify(15, TimeUnit.SECONDS)
-                .getSession()) {
-
-                MinaSSHPublicKeyAuthenticator instance = new 
-                    MinaSSHPublicKeyAuthenticator(connection, userWithPassphrase, null);
-                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
-                assertThat(instance.canAuthenticate(), is(true));
-                assertThat(instance.authenticate(TaskListener.NULL), is(true));
-                assertThat(instance.isAuthenticated(), is(true));
-                assertThat(connection.getUsername(), is(user.getUsername()));
-            }
-        }
-    }
-
-    @Test
     public void testFactory() throws Exception {
         try (SshClient sshClient = SshClient.setUpDefaultClient()) {
             sshClient.start();

--- a/mina-sshd-api-core/src/main/test/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPublicKeyAuthenticatorTest.java
+++ b/mina-sshd-api-core/src/main/test/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPublicKeyAuthenticatorTest.java
@@ -1,0 +1,315 @@
+package io.jenkins.plugins.mina_sshd_api.core.authenticators;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.TaskListener;
+import hudson.util.Secret;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MinaSSHPublicKeyAuthenticatorTest {
+
+    private static final Logger LOGGER = Logger.getLogger(MinaSSHPublicKeyAuthenticatorTest.class.getName());
+
+    private SshServer sshd;
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    private final SSHUserPrivateKey user = new SSHUserPrivateKey() {
+
+        @NonNull
+        public String getUsername() {
+            return "foomanchu";
+        }
+
+        @NonNull
+        public String getDescription() {
+            return "";
+        }
+
+        @NonNull
+        public String getId() {
+            return "";
+        }
+
+        public CredentialsScope getScope() {
+            return CredentialsScope.SYSTEM;
+        }
+
+        @NonNull
+        public CredentialsDescriptor getDescriptor() {
+            return new CredentialsDescriptor() {
+                @Override
+                @NonNull
+                public String getDisplayName() {
+                    return "";
+                }
+            };
+        }
+
+        @NonNull
+        public String getPrivateKey() {
+            // just want a valid key... I generated this and have thrown it away (other than here)
+            // do not use other than in this test
+            return "-----BEGIN RSA PRIVATE KEY-----\n"
+                + "MIICWQIBAAKBgQDADDwooNPJNQB4N4bJPiBgq/rkWKMABApX0w4trSkkX5q+l+CL\n"
+                + "CuddGGAsAu6XPari8v49ipbBmHqRLP9+X3ARGWKU2gDvGTBr99/ReUl2YgVjCwy+\n"
+                + "KMrGCN7SNTgRo6StwVaPhh6pUpNTQciDe/kOwUnQFWSM6/lwkOD1Uod45wIBIwKB\n"
+                + "gHi3O8HELVnmzRhdaqphkLHLL/0/B18Ye4epPBy1/JqFPLJQ1kjFBnUIAe/HVCSN\n"
+                + "KZX30wIcmUZ9GdeYoJiTwsfTy9t2KwHjqrapTfiekVZAW+3iDBqRZMxQ5MoK7b6g\n"
+                + "w5HrrtrtPfYuAsBnYjIS6qsKAVT3vdolJ5eai/RlPO4LAkEA76YuUozC/dW7Ox+R\n"
+                + "1Njd6cWJsRVXGemkSYY/rSh0SbfHAebqL/bDg8xXim9UiuD9Hc6md3glHQj6iKvl\n"
+                + "BxWq4QJBAM0moKiM16WFSFJP1wVDj0Bnx6DkJYSpf5u+C0ghBVoqIYKq6/P/gRE2\n"
+                + "+ColsLu6AYftaEJVpAgxeTU/IsGoJMcCQHRmqMkCipiMYkFJ2R49cxnGWNJa0ojt\n"
+                + "03QrQ3/9tNNZQ2dS5sbW8UAEKoURgNW9vMVVvpHMpE/uaw8u65W6ESsCQDTAyjn4\n"
+                + "VLWIrDJsTTveLCaBFhNt3cMHA45ysnGiF1GzD+5mdzAdITBP9qvAjIgLQjjlRrH4\n"
+                + "w8eXsXQXjJgyjR0CQHfvhiMPG5pWwmXpsEOFo6GKSvOC/5sNEcnddenuO/2T7WWi\n"
+                + "o1LQh9naeuX8gti0vNR8+KtMEaIcJJeWnk56AVY=\n"
+                + "-----END RSA PRIVATE KEY-----\n";
+        }
+
+        @CheckForNull
+        public Secret getPassphrase() {
+            return null;
+        }
+
+        @NonNull
+        public List<String> getPrivateKeys() {
+            return Collections.singletonList(getPrivateKey());
+        }
+    };
+
+
+    private final SSHUserPrivateKey userWithPassphrase = new SSHUserPrivateKey() {
+
+        @NonNull
+        public String getUsername() {
+            return "foomanchu";
+        }
+
+        @NonNull
+        public String getDescription() {
+            return "";
+        }
+
+        @NonNull
+        public String getId() {
+            return "";
+        }
+
+        public CredentialsScope getScope() {
+            return CredentialsScope.SYSTEM;
+        }
+
+        @NonNull
+        public CredentialsDescriptor getDescriptor() {
+            return new CredentialsDescriptor() {
+                @Override
+                @NonNull
+                public String getDisplayName() {
+                    return "";
+                }
+            };
+        }
+
+        @NonNull
+        @Override
+        public String getPrivateKey() {
+            // just want a valid key... I generated this and have thrown it away (other than here)
+            // do not use other than in this test
+            return "-----BEGIN RSA PRIVATE KEY-----\n" +
+                "Proc-Type: 4,ENCRYPTED\n" +
+                "DEK-Info: AES-128-CBC,3D392A6AD3BB4B6F6931E8B6AFAC44C3\n" +
+                "\n" +
+                "eKjTixX+AoVPmfWz0MCQwmu9ZCcunXu3Ks+l7E7j4W6O1tI+5Xxo19jyFyVHKcSP\n" +
+                "dgxTvko3V9E3fyG120C6fqkdFijp//s/RwzafGh1rDf7l4W2DBX5euyaE+mQG9PV\n" +
+                "LStH4AEPSVnGiBmp1Faz/Xcj5NMCwZxOo0cImJQL3tnm8X8pQaPJknWmJea+Tsu/\n" +
+                "+Y82ysygXSvX7phoYSEIg63VGxbhGLFNNptRdNOi4RfE/dP0/WJZo+xyNCMOclSH\n" +
+                "fkXZ6ZGZTDnQ7v3gVw91v0t7eDpPjkdFI8OqwZhnTOxZh9d4xtuqdrbPlEgO2Dxa\n" +
+                "Mn7sgSfFipRyGgyancylIFVJzOpr4Hp/9Xndm6oSyoeUrp2tbJ2CBIC1hYFIMrYS\n" +
+                "Kzj9PAvz4l6elHVQ3dJS5LnNRNrYZf2yNCKJB3u1YSUGYDO4wNmSEL+MxjhMqyAg\n" +
+                "avPbxGNJMgXHCcMqXjcWtTW3XAEvyl6sTNRu210exv1xeWePICaCi0/EPbvE6Ttv\n" +
+                "w8ARLIJr6J3EkaIqt/mhckfjRAS4iNC0xmqAgnxJwrCulKA6JkXtWtXmLvCAau9q\n" +
+                "ukEWbqV6fXnTrALYXTu0mBw8jylBDK1RWQ++GfyPOsUPqvwGK6o3YQLoQIoFxEBP\n" +
+                "k+tgWVtgC6PxbAQSBOrfgPhYNQJVkdLZv6/dLxhuyww1XhBL3r2k7ydJvFmNKDyG\n" +
+                "7Tg6dClgMSSDr9+fszxSQO8e/MhigZlA3ajFStihH3E0PbSDspL+Vwo3jYxeaU3Z\n" +
+                "9fVS+uqzRO+bfAo6n/7lncg1os48HHUruAvtwKdbTXJabONdpxhY+r+GjeohABhz\n" +
+                "X73sld0u9XgsUgZtC7TEB8mrNFXrSkn6e3oSskjNT8ETISuYX5e9/AaRXzgSqUqw\n" +
+                "RUWZz2VrKuVtPycnSo3ITTe4m4SHJ7xrK0SrMZ5Rawlhpcu7TZF4LPqMdAzN+2XS\n" +
+                "6CDl9lDq6yI608/cpVwRj+FG6gYGd5fCQCfRukBj+GjAMJ4rtLcebxNh7zqoxflo\n" +
+                "1Swgcg2t0/A7xvgV/CX1dNg3NE2DTnVh72gkATQKj5TsoVRR2CndlF+b9ljljTMW\n" +
+                "YiM0AknwBYZm3KEuHBynzNxHUhk6Dbe8wWv2wAxF/eOnGGtlFiFHz3gDE2OJy4xJ\n" +
+                "HhP6mAQ1UU6N0JxCPRvywiTfpiAFfO5C/xCKC0rlXgE7EY/wxW+5NnWPiRdNxetD\n" +
+                "oti8ydeOFbR1mLUUT7Ug6H53Rm9ZcEnMVXjrtqQLU7o/j63vbO5uO4MkOUkxRvBV\n" +
+                "ETgAY68uE6+aPVqasifvJT6k/3VvsIfmv38cbW73EqB6JvRsZVLmij83Zosoa2PD\n" +
+                "8XP27OjWPabwRLdBuji2uGpK27AcfD4C0ehL+v+WHzU6bQFTp/D2nq4gziojSaej\n" +
+                "uM98tUXrcxSrnNd24CqC1vzy5kj8Bq+h3akltiV/eG7QEtDaZAheWSLSiZJE+T/H\n" +
+                "WWXczswVkc24Po3gBcn8bx+zhnqekYgOithEPdNPI1HQA5LrT34549gp+aYy+vkE\n" +
+                "ZNjVeV74Ok84l2cjLm8k6MwdIdtDt9EvT6xxWJi8GGRtR2bJnZSByEuzB5GT7Z3s\n" +
+                "dPENV3cCsQsEzO6tHgCvSvfuIkqdWMzo8GOloHTYm23ihfTYUyYldMuDYHF1MC1F\n" +
+                "te8B6rVghhmXEG6YaiUo3BRIE9ye1M1f/lpiJ4pit22Od7FBiKx5PMjDF8+ITzeO\n" +
+                "mJ7OtBG/0f/+o76fjbZQXFsgRbHSMWgvdhHNb6iM87tNmZJpdZSfY2lu1Aszsw/t\n" +
+                "neuuGAVJ9sRpck2PGionEYRaGCNK7ajNZJBVEZn/zyp44iKEWvSyeuTHrmt7xFGB\n" +
+                "jNIHiqAaFOli/YCTuXtaVYuIqnp1e27USKiHFj/ijG0bbQCT2bur9REA7x/ug/zL\n" +
+                "S9HPsS6VhioqJsamG6xpl51h9NLaO2lNyrmByapVtCg/R2WZ2t80fDuNifT1+ONk\n" +
+                "Tlufz0hF2GQpb0qst7YZImcs0y1/r4GIOTvnaPhEjfv4ymi1bKNvQennwed4Eu2A\n" +
+                "UXcF35Bblwilz3xunPbSdNMPW4UIc+GixY8RNDB9i9nMqPhlXW059c+RNHITE/WX\n" +
+                "+EIMgUYKMg8suxlQzMLl2kSWJjUyeC5VUIIt09a6Vnj9OWrPDeTnhYHjvrKdIPMY\n" +
+                "QfwaWLuUZozKyJbRsPeeEVXveEOEH4m3zpfyIC6Wv5OXBM2Ysdys3DzAJUgO/NXh\n" +
+                "vHZprKnJlFTitUO3ySuw/q4lJFCt8VsMXceEoNzOspCwhtCiN0miXbA9D1biLAqR\n" +
+                "+CDpQnpTUlJW6nDRGb/y3CmEjW37/DXr5CcaQ8ADkAVeaZMypFF6T2TWEar59SYP\n" +
+                "-----END RSA PRIVATE KEY-----\n";
+        }
+
+        @NonNull
+        @Override
+        public Secret getPassphrase() {
+            return Secret.fromString("passphrase");
+        }
+
+        @NonNull
+        @Override
+        public List<String> getPrivateKeys() {
+            return Collections.singletonList(getPrivateKey());
+        }
+    };
+
+    @After
+    public void tearDown() {
+        if (sshd != null) {
+            try {
+                sshd.stop(true);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Problems shutting down ssh server", e);
+            }
+        }
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        sshd = SshServer.setUpDefaultServer();
+        sshd.setHost("localhost");
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        sshd.setPublickeyAuthenticator((s, publicKey, serverSession) -> user.getUsername().equals(s));
+        sshd.setUserAuthFactories(Collections.singletonList(new UserAuthPublicKeyFactory()));
+        try {
+            sshd.start();
+            LOGGER.log(Level.INFO, "Started ssh Server");
+        } catch (Throwable e) {
+            LOGGER.log(Level.WARNING, "Problems starting ssh server", e);
+            try {
+                sshd.stop();
+            } catch (Throwable t) {
+                LOGGER.log(Level.WARNING, "Problems shutting down ssh server", t);
+            }
+            throw e;
+        }
+    }
+
+    @Test
+    public void testAuthenticate() throws Exception {
+        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
+            sshClient.start();
+            try (ClientSession connection = sshClient
+                .connect(user.getUsername(), sshd.getHost(), sshd.getPort())
+                .verify(15, TimeUnit.SECONDS)
+                .getSession()) {
+
+                MinaSSHPublicKeyAuthenticator instance = 
+                    new MinaSSHPublicKeyAuthenticator(connection, user, null);
+                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
+                assertThat(instance.canAuthenticate(), is(true));
+                assertThat(instance.authenticate(TaskListener.NULL), is(true));
+                assertThat(instance.isAuthenticated(), is(true));
+                assertThat(connection.getUsername(), is(user.getUsername()));
+            }
+        }
+    }
+
+    @Test
+    public void testAuthenticateWithPassphrase() throws Exception {
+        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
+            sshClient.start();
+            try (ClientSession connection = sshClient
+                .connect(userWithPassphrase.getUsername(), sshd.getHost(), sshd.getPort())
+                .verify(15, TimeUnit.SECONDS)
+                .getSession()) {
+
+                MinaSSHPublicKeyAuthenticator instance = new 
+                    MinaSSHPublicKeyAuthenticator(connection, userWithPassphrase, null);
+                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
+                assertThat(instance.canAuthenticate(), is(true));
+                assertThat(instance.authenticate(TaskListener.NULL), is(true));
+                assertThat(instance.isAuthenticated(), is(true));
+                assertThat(connection.getUsername(), is(user.getUsername()));
+            }
+        }
+    }
+
+    @Test
+    public void testFactory() throws Exception {
+        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
+            sshClient.start();
+            try (ClientSession connection = sshClient
+                .connect(user.getUsername(), sshd.getHost(), sshd.getPort())
+                .verify(15, TimeUnit.SECONDS)
+                .getSession()) {
+
+                SSHAuthenticator<Object, StandardUsernameCredentials> instance = 
+                    SSHAuthenticator.newInstance(connection, user, null);
+                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
+                assertThat(instance.canAuthenticate(), is(true));
+                assertThat(instance.authenticate(TaskListener.NULL), is(true));
+                assertThat(instance.isAuthenticated(), is(true));
+                assertThat(connection.getUsername(), is(user.getUsername()));
+            }
+
+        }
+    }
+
+    @Test
+    public void testFactoryWithPassphrase() throws Exception {
+        try (SshClient sshClient = SshClient.setUpDefaultClient()) {
+            sshClient.start();
+            try (ClientSession connection = sshClient
+                .connect(userWithPassphrase.getUsername(), sshd.getHost(), sshd.getPort())
+                .verify(15, TimeUnit.SECONDS)
+                .getSession()) {
+
+                SSHAuthenticator<Object, StandardUsernameCredentials> instance = 
+                    SSHAuthenticator.newInstance(connection, userWithPassphrase, null);
+                assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
+                assertThat(instance.canAuthenticate(), is(true));
+                assertThat(instance.authenticate(TaskListener.NULL), is(true));
+                assertThat(instance.isAuthenticated(), is(true));
+                assertThat(connection.getUsername(), is(user.getUsername()));
+            }
+
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <revision>2.8.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <autoVersionSubmodules>true</autoVersionSubmodules>
     </properties>
     


### PR DESCRIPTION
(move https://github.com/jenkinsci/ssh-credentials-plugin/pull/126 here with `ssh-credentials` as an optional dependency)

[JENKINS-64105](https://issues.jenkins.io/browse/JENKINS-64105): Added `MinaSSHPasswordKeyAuthenticator` and `MinaSSHPublicKeyKeyAuthenticator` to provide authentication support with an Apache Mina SSHD [ClientSession](https://javadoc.io/static/org.apache.sshd/sshd-core/2.8.0/org/apache/sshd/client/session/ClientSession.html).

See also:

* https://javadoc.io/static/org.apache.sshd/sshd-core/2.8.0/org/apache/sshd/client/session/ClientSession.html
* https://mina.apache.org/mina-project/userguide/ch4-session/ch4-session.html
* https://github.com/apache/mina-sshd/blob/master/docs/client-setup.md

Note: also added system property to control the auth timeout when doing the auth (those defaults to **15s** which I believe is more than reasonable):

* `io.jenkins.plugins.mina_sshd_api.core.authenticators.MinaSSHPasswordKeyAuthenticator.authTimeout`
* `io.jenkins.plugins.mina_sshd_api.core.authenticators.MinaSSHPublicKeyAuthenticator.authTimeout`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue