### PR TITLE
Update minimal required Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <revision>2.8.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
-        <jenkins.version>2.289.3</jenkins.version>
+        <jenkins.version>2.346.1</jenkins.version>
         <autoVersionSubmodules>true</autoVersionSubmodules>
     </properties>
     


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

---

This Pull Request is fixing the minimal required Jenkins version the plugin needs now.

Why: in https://github.com/jenkinsci/mina-sshd-api-plugin/pull/14 the following transitive change has been adopted via the `bom` plugin:
> Bump ssh-credentials from 287.v0c2c2889c28d to 291.v8211e4f8efb_c in /bom-weekly ([#1238](https://github-redirect.dependabot.com/jenkinsci/bom/issues/1238)) [@​dependabot](https://github.com/dependabot)

`ssh-credential` version `291` now demands the minimal Jenkins version 2.346.1: https://github.com/jenkinsci/ssh-credentials-plugin/blob/master/pom.xml#L74

Trying to run the current version of `mina-sshd-api-plugin:2.8.0-30.vf9df64641cb_d` (which is required by `sshd`) prevents many other plugins from loading (due to circular dependencies):

> SEVERE	hudson.PluginManager$1$3$2$1#reactOnCycle: found cycle in plugin dependencies: (root=Plugin:sshd, deactivating all involved) Plugin:sshd -> Plugin:mina-sshd-api-core -> Plugin:ssh-credentials -> Plugin:credentials -> Plugin:configuration-as-code -> Plugin:commons-text-api -> Plugin:commons-lang3-api -> Plugin:sshd 

Previously working version: `2.8.0-21.v493b_6b_db_22c6`

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
