### PR TITLE
Add OSGi API for git client plugin use

### DIFF
--- a/mina-sshd-api-osgi/pom.xml
+++ b/mina-sshd-api-osgi/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+        <artifactId>mina-sshd-api-parent</artifactId>
+        <version>${revision}-${changelist}</version>
+    </parent>
+
+    <artifactId>mina-sshd-api-osgi</artifactId>
+    <packaging>hpi</packaging>
+
+    <name>Mina SSHD API :: OSGi</name>
+    <url>https://github.com/jenkinsci/mina-sshd-api-plugin</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+            <artifactId>mina-sshd-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-osgi</artifactId>
+            <version>${revision}</version>
+            <exclusions>
+                <!-- Provided by dependencies -->
+                <exclusion>
+                    <groupId>org.apache.sshd</groupId>
+                    <artifactId>sshd-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.sshd</groupId>
+                    <artifactId>sshd-core</artifactId>
+                </exclusion>
+                <!-- Provided by Jenkins core -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/mina-sshd-api-osgi/src/main/resources/index.jelly
+++ b/mina-sshd-api-osgi/src/main/resources/index.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<div>
+    Provides the OSGi module of <a href="https://mina.apache.org/sshd-project/">Apache Mina SSHD</a> to plugins.
+</div>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <modules>
         <module>mina-sshd-api-common</module>
         <module>mina-sshd-api-core</module>
+        <module>mina-sshd-api-osgi</module>
         <module>mina-sshd-api-scp</module>
         <module>mina-sshd-api-sftp</module>
     </modules>


### PR DESCRIPTION
## Add OSGi API plugin for use by git client plugin

The git client plugin bundles JGit so that Jenkins consumers of the JGit API can use the JGit version that is already included in the git client plugin.  As part of https://issues.jenkins.io/browse/JENKINS-69159 and https://github.com/jenkinsci/git-client-plugin/pull/956 the git client plugin is switching to use Apache Mina ssh.

The OSGi jar file is included in the git client plugin as a transitive dependency with https://github.com/jenkinsci/git-client-plugin/pull/956 .  I think it will be better to make it an explicit API plugin rather than having it included as a transitive dependency in the git client plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

As an open question, is it time to switch the Jenkins minimum version of this library plugin from 2.319.3 to 2.361.4?  I'm fine either way, but since the changes I'm proposing will require a new release, maybe this is the right time to also switch from Java 8 to Java 11?