### PR TITLE
Bump sshd from 2.10.0 to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </scm>
 
     <properties>
-        <revision>2.10.0</revision>
+        <revision>2.11.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
         <jenkins.version>2.361.4</jenkins.version>


### PR DESCRIPTION
SSHD 2.11.0 is out: https://github.com/apache/mina-sshd/blob/master/docs/changes/2.11.0.md

Among the changes, I did not find any usage of the SSHD `SftpEventListener` and `KeepAliveHandler` in the `jenkinsci` (and also checked `cloudbees` org).
There is a rewrite of the SFTP Channel pool that is good to be aware of https://github.com/tomaswolf/mina-sshd/blob/31e73f768b5c4bf9ed00942184e1570d3365be21/docs/technical/sftp_filesystem.md#choosing-the-pool-size

### Testing done

N/A

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
