### PR TITLE
Use Apache Mina 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </scm>
 
     <properties>
-        <revision>2.12.0</revision>
+        <revision>2.12.1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
         <jenkins.version>2.387.3</jenkins.version>


### PR DESCRIPTION
## Use Apache Mina 2.12.1

Updates `org.apache.sshd:sshd` from 2.12.0 to 2.12.1
- [Release notes](https://github.com/apache/mina-sshd/releases/tag/sshd-2.12.1)
- [Changelog](https://github.com/apache/mina-sshd/blob/master/docs/changes/2.12.1.md)

Was not recommnded by Dependabot due to a bug in Dependabot.

More details in https://github.com/jenkins-infra/helpdesk/issues/3919#issuecomment-2023726186

### Testing done

Will perform testing with an incremental build from ci.jenkins.io.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
