### PR TITLE
add bouncycastle / eddsa plugins as optional and remove trilead

### DIFF
--- a/mina-sshd-api-common/pom.xml
+++ b/mina-sshd-api-common/pom.xml
@@ -36,5 +36,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>eddsa-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>bouncycastle-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 </project>

--- a/mina-sshd-api-core/pom.xml
+++ b/mina-sshd-api-core/pom.xml
@@ -50,10 +50,5 @@
             <artifactId>ssh-credentials</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>trilead-api</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <revision>2.12.1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
         <autoVersionSubmodules>true</autoVersionSubmodules>
     </properties>
 
@@ -76,10 +76,19 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2543.vfb_1a_5fb_9496d</version>
+                <artifactId>bom-2.426.x</artifactId>
+                <!-- 
+                     TODO remove the eddsa-api management below when the bom upadte includes eddsa-api
+                     https://github.com/jenkinsci/bom/pull/3230
+                -->
+                <version>3041.ve87ce2cdf223</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>eddsa-api</artifactId>
+                <version>0.3.0-4.v84c6f0f4969e</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
@@ -90,12 +99,6 @@
                 <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
                 <artifactId>mina-sshd-api-core</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>ssh-credentials</artifactId>
-                <!-- we need a version which mark trilead-api as optional -->
-                <version>337.v395d2403ccd4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Apache Mina only currently supports [EDDSA curves](https://github.com/apache/mina-sshd/blob/5a78e6dfe37ec982de8eec7abf449e83b3c984ae/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java#L561-L671) [via the eddsa library](https://github.com/apache/mina-sshd/blob/5a78e6dfe37ec982de8eec7abf449e83b3c984ae/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java#L563-L571).

It can additionally support [more types if BouncyCastle](https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java#L534-L547) is present.

Whilst the `eddsa` library should not be needed (as BC supports this) mina makes no use of this, nor will it attempt to use EdDSA from the java platform if running on jdk > 15 that has this added.

As such these 2 libraries are added via optional plugins, so that if they are present then this extra support will be available.

obsoletes #91 
<!-- Please describe your pull request here. -->

### Testing done

has been used in interactice testing with a customer git and ssh server in combination with https://github.com/jenkinsci/git-client-plugin/pull/1127 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
