### PR TITLE
Use Apache Mina NIO2 framework instead of jdk provided NIO2 framework

### DIFF
--- a/mina-sshd-api-core/pom.xml
+++ b/mina-sshd-api-core/pom.xml
@@ -46,6 +46,17 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.mina</groupId>
+            <artifactId>mina-core</artifactId>
+            <version>2.0.23</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-mina</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
             <optional>true</optional>

--- a/mina-sshd-api-core/pom.xml
+++ b/mina-sshd-api-core/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.0.23</version>
+            <version>2.0.26</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

This should provide better performance. To disable this Jenkins can be started using the system property  `-Dorg.apache.sshd.common.io.IoServiceFactoryFactory=org.apache.sshd.common.io.nio2.Nio2ServiceFactoryFactory`

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
