### PR TITLE
Override jth version using property instead of dependency block

### DIFF
--- a/mina-sshd-api-common/pom.xml
+++ b/mina-sshd-api-common/pom.xml
@@ -48,12 +48,6 @@
         </dependency>
         <!-- TODO remove when those versions are offered by BOM -->
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <version>2270.v87a_0ea_b_54da_0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.jenkins.test.fips</groupId>
             <artifactId>fips-bundle-test</artifactId>
             <version>23.v76d4fd57f5b_d</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
         <jenkins.version>2.426.3</jenkins.version>
         <autoVersionSubmodules>true</autoVersionSubmodules>
+        <!-- TODO remove once offered by BOM -->
+        <jenkins-test-harness.version>2270.v87a_0ea_b_54da_0</jenkins-test-harness.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
         <jenkins.version>2.426.3</jenkins.version>
         <autoVersionSubmodules>true</autoVersionSubmodules>
-        <!-- TODO remove once offered by BOM -->
+        <!-- TODO remove once offered by parent -->
         <jenkins-test-harness.version>2270.v87a_0ea_b_54da_0</jenkins-test-harness.version>
     </properties>
 


### PR DESCRIPTION
Amends #114

PCT overrides the JTH version using properties to adjust with recent Jenkins version. Plugins should avoid overriding the dependency block and instead override the existing property.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
