### PR TITLE
Use Apache Mina SSHD 2.15.0

### DIFF
--- a/mina-sshd-api-core/src/test/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticatorTest.java
+++ b/mina-sshd-api-core/src/test/java/io/jenkins/plugins/mina_sshd_api/core/authenticators/MinaSSHPasswordKeyAuthenticatorTest.java
@@ -32,11 +32,10 @@ public class MinaSSHPasswordKeyAuthenticatorTest {
 
     private SshServer sshd;
 
+    private StandardUsernamePasswordCredentials user;
+
     @Rule
     public JenkinsRule r = new JenkinsRule();
-
-    private final StandardUsernamePasswordCredentials user =
-        new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, null, "foobar", "foobar", "foomanchu");
 
     @After
     public void tearDown() {
@@ -50,7 +49,8 @@ public class MinaSSHPasswordKeyAuthenticatorTest {
     }
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() throws Exception {
+        user = new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, null, "foobar", "foobar", "foomanchu");
         sshd = SshServer.setUpDefaultServer();
         sshd.setHost("localhost");
         sshd.setPort(0);
@@ -80,7 +80,7 @@ public class MinaSSHPasswordKeyAuthenticatorTest {
                 .verify(30, TimeUnit.SECONDS)
                 .getClientSession()) {
 
-                SSHAuthenticator<Object, StandardUsernameCredentials> instance = 
+                SSHAuthenticator<Object, StandardUsernameCredentials> instance =
                     SSHAuthenticator.newInstance(connection, user);
                 assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
                 assertThat(instance.canAuthenticate(), is(true));

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.8</version>
+        <version>5.9</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <autoVersionSubmodules>true</autoVersionSubmodules>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </scm>
 
     <properties>
-        <revision>2.14.0</revision>
+        <revision>2.15.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>4051.v78dce3ce8b_d6</version>
+                <version>4545.v56392b_7ca_7b_a_</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,6 @@
         <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <autoVersionSubmodules>true</autoVersionSubmodules>
-        <!-- TODO remove once offered by parent -->
-        <jenkins-test-harness.version>2270.v87a_0ea_b_54da_0</jenkins-test-harness.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -93,18 +93,6 @@
                 <artifactId>mina-sshd-api-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>5.12.0</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>3.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.86</version>
+        <version>5.8</version>
         <relativePath/>
     </parent>
 
@@ -48,8 +48,8 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/mina-sshd-api-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.426</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <autoVersionSubmodules>true</autoVersionSubmodules>
         <!-- TODO remove once offered by parent -->
         <jenkins-test-harness.version>2270.v87a_0ea_b_54da_0</jenkins-test-harness.version>
@@ -81,7 +81,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3208.vb_21177d4b_cd9</version>
+                <version>4051.v78dce3ce8b_d6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Use Apache Mina SSHD 2.15.0

Eclipse JGit 7.2.0 needs Apache Mina SSHD 2.15.0.

The [mailing list](https://lists.apache.org/thread/zrt5l2oxgon83lrgr6jt05bvt824yqxz) announces the Feb 25, 2025 release of Apache Mina SSHD 2.15.0 with the following key features:

* [GH-606](https://github.com/apache/mina-sshd/issues/606) Support ML-KEM PQC hybrid key exchanges
* [GH-652](https://github.com/apache/mina-sshd/issues/652) New method KnownHostsServerKeyVerifier.handleRevokedKey()
* [SSHD-988](https://issues.apache.org/jira/browse/SSHD-988) Support ed25519 keys via the Bouncy Castle library

Bug fixes include:

* [GH-618](https://github.com/apache/mina-sshd/issues/618) Fix reading an OpenSshCertificate from a Buffer
* [GH-626](https://github.com/apache/mina-sshd/issues/626) Enable Streaming.Async for ChannelDirectTcpip
* [GH-628](https://github.com/apache/mina-sshd/issues/628) SFTP: fix reading directories with trailing blanks in the name
* [GH-636](https://github.com/apache/mina-sshd/issues/636) Fix handling of unsupported key types in known_hosts file
* [GH-642](https://github.com/apache/mina-sshd/issues/642) Do not use SecureRandom.getInstanceString() due to possible entropy starvation (regression in 2.14.0)
* [GH-654](https://github.com/apache/mina-sshd/issues/654) Fix test dependency for assertj in sshd-contrib

Includes changes from other pull requests for convenience, including:

* https://github.com/jenkinsci/mina-sshd-api-plugin/pull/151

Supersedes the pull requests:

* https://github.com/jenkinsci/mina-sshd-api-plugin/pull/148
* https://github.com/jenkinsci/mina-sshd-api-plugin/pull/149
* https://github.com/jenkinsci/mina-sshd-api-plugin/pull/152

Removes the pinned declaration of test harness version since the parent pom includes that version.

Removes the dependency management entries for junit-bom and hamcrest because those are provided by the parent pom.

### Testing done

Pull request has been tested in many repositories as part of testing the git client plugin pull request that is evaluating JGit 7.2.0.  That pull request is:

* https://github.com/jenkinsci/git-client-plugin/pull/1262

Testing is complete, including:

* [x] Pass git client plugin automated testing with JGit 7.2.0 ([PR-1262](https://github.com/jenkinsci/git-client-plugin/pull/1262))
* [x] Pass plugin BOM testing using an incremental build
   * [x] https://github.com/jenkinsci/bom/pull/4663
* [x] Pass acceptance test harness tests using an incremental build
    * [x] https://github.com/jenkinsci/acceptance-test-harness/pull/1933
* [x] Pass interactive testing in my home lab that checks several different Git providers for SSH and HTTPS access

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
