### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/mina-sshd-api-common/pom.xml
+++ b/mina-sshd-api-common/pom.xml
@@ -46,12 +46,5 @@
             <artifactId>bouncycastle-api</artifactId>
             <optional>true</optional>
         </dependency>
-        <!-- TODO remove when those versions are offered by BOM -->
-        <dependency>
-            <groupId>io.jenkins.test.fips</groupId>
-            <artifactId>fips-bundle-test</artifactId>
-            <version>27.va_f689db_8c5ea_</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Testing done

```
$ mvn dependency:tree -Dverbose | grep fips-bundle-test
[INFO] |  +- io.jenkins.test.fips:fips-bundle-test:jar:27.va_f689db_8c5ea_:test
[INFO] |  +- io.jenkins.test.fips:fips-bundle-test:jar:27.va_f689db_8c5ea_:test
[INFO] |  +- io.jenkins.test.fips:fips-bundle-test:jar:27.va_f689db_8c5ea_:test
[INFO] |  +- io.jenkins.test.fips:fips-bundle-test:jar:27.va_f689db_8c5ea_:test
[INFO] |  +- io.jenkins.test.fips:fips-bundle-test:jar:27.va_f689db_8c5ea_:test
```

which is the same as the version previously being explicitly managed before this PR.